### PR TITLE
as_child for Button

### DIFF
--- a/singlestage/src/as_child.rs
+++ b/singlestage/src/as_child.rs
@@ -1,0 +1,7 @@
+use leptos::prelude::*;
+
+use crate::patch_class::PatchClass;
+#[component]
+pub fn AsChild(#[prop(optional, into)] class:TextProp, children:Children) -> impl IntoView{
+    view! { {children().add_any_attr(leptos::tachys::html::class::class(PatchClass(class)))} }
+}

--- a/singlestage/src/components/button/mod.rs
+++ b/singlestage/src/components/button/mod.rs
@@ -1,4 +1,5 @@
-use leptos::prelude::*;
+use leptos::{either::Either, prelude::*};
+use crate::patch_class::PatchClass;
 
 /// Displays a button.
 #[component]
@@ -180,6 +181,9 @@ pub fn Button(
     /// Variants: primary | secondary | outline | ghost | link | destructive
     #[prop(optional, into)]
     variant: MaybeProp<String>,
+
+    /// asChild
+    #[prop(optional)] as_child: bool,
 ) -> impl IntoView {
     let global_attrs_1 = view! {
         <{..}
@@ -236,44 +240,91 @@ pub fn Button(
         />
     };
 
-    view! {
-        <button
-            class=move || {
-                format!(
-                    "{} {} {}",
-                    match variant.get().unwrap_or_default().as_str() {
-                        "primary" => "singlestage-btn-primary",
-                        "secondary" => "singlestage-btn-secondary",
-                        "outline" => "singlestage-btn-outline",
-                        "ghost" => "singlestage-btn-ghost",
-                        "link" => "singlestage-btn-link",
-                        "destructive" => "singlestage-btn-destructive",
-                        _ => "singlestage-btn-primary",
-                    },
-                    match size.get().unwrap_or_default().as_str() {
-                        "sm" => "singlestage-btn-sm",
-                        "small" => "singlestage-btn-sm",
-                        "lg" => "singlestage-btn-lg",
-                        "large" => "singlestage-btn-lg",
-                        "icon" => "singlestage-btn-icon",
-                        "sm-icon" => "singlestage-btn-sm-icon",
-                        "icon-sm" => "singlestage-btn-sm-icon",
-                        "lg-icon" => "singlestage-btn-lg-icon",
-                        "icon-lg" => "singlestage-btn-lg-icon",
-                        _ => "",
-                    },
-                    class.get().unwrap_or_default(),
+    if as_child {
+        Either::Right(view! {
+            {children()
+                .add_any_attr(
+                    leptos::tachys::html::class::class(
+                        PatchClass(
+                            Signal::derive(move || {
+                                format!(
+                                    "{} {} {}",
+                                    match variant.get().unwrap_or_default().as_str() {
+                                        "primary" => "singlestage-btn-primary",
+                                        "secondary" => "singlestage-btn-secondary",
+                                        "outline" => "singlestage-btn-outline",
+                                        "ghost" => "singlestage-btn-ghost",
+                                        "link" => "singlestage-btn-link",
+                                        "destructive" => "singlestage-btn-destructive",
+                                        _ => "singlestage-btn-primary",
+                                    },
+                                    match size.get().unwrap_or_default().as_str() {
+                                        "sm" => "singlestage-btn-sm",
+                                        "small" => "singlestage-btn-sm",
+                                        "lg" => "singlestage-btn-lg",
+                                        "large" => "singlestage-btn-lg",
+                                        "icon" => "singlestage-btn-icon",
+                                        "sm-icon" => "singlestage-btn-sm-icon",
+                                        "icon-sm" => "singlestage-btn-sm-icon",
+                                        "lg-icon" => "singlestage-btn-lg-icon",
+                                        "icon-lg" => "singlestage-btn-lg-icon",
+                                        _ => "",
+                                    },
+                                    class.get().unwrap_or_default(),
+                                )
+                            }),
+                        ),
+                    ),
                 )
-            }
-            disabled=disabled.get_untracked()
-            prop:disabled=move || disabled.get()
-            type=button_type.get()
+                .add_any_attr(
+                    leptos::tachys::html::property::prop("disabled", disabled.get_untracked()),
+                )
+                .attr("disabled", disabled.get_untracked())
+                .attr("type", button_type.get())
+                .add_any_attr(global_attrs_1)
+                .add_any_attr(global_attrs_2)
+                .add_any_attr(button_attrs)}
+        })
+    } else {
+        Either::Left(view! {
+            <button
+                class=move || {
+                    format!(
+                        "{} {} {}",
+                        match variant.get().unwrap_or_default().as_str() {
+                            "primary" => "singlestage-btn-primary",
+                            "secondary" => "singlestage-btn-secondary",
+                            "outline" => "singlestage-btn-outline",
+                            "ghost" => "singlestage-btn-ghost",
+                            "link" => "singlestage-btn-link",
+                            "destructive" => "singlestage-btn-destructive",
+                            _ => "singlestage-btn-primary",
+                        },
+                        match size.get().unwrap_or_default().as_str() {
+                            "sm" => "singlestage-btn-sm",
+                            "small" => "singlestage-btn-sm",
+                            "lg" => "singlestage-btn-lg",
+                            "large" => "singlestage-btn-lg",
+                            "icon" => "singlestage-btn-icon",
+                            "sm-icon" => "singlestage-btn-sm-icon",
+                            "icon-sm" => "singlestage-btn-sm-icon",
+                            "lg-icon" => "singlestage-btn-lg-icon",
+                            "icon-lg" => "singlestage-btn-lg-icon",
+                            _ => "",
+                        },
+                        class.get().unwrap_or_default(),
+                    )
+                }
+                disabled=disabled.get_untracked()
+                prop:disabled=move || disabled.get()
+                type=button_type.get()
 
-            {..global_attrs_1}
-            {..global_attrs_2}
-            {..button_attrs}
-        >
-            {children()}
-        </button>
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </button>
+        })
     }
 }

--- a/singlestage/src/components/button/mod.rs
+++ b/singlestage/src/components/button/mod.rs
@@ -1,5 +1,5 @@
 use leptos::{either::Either, prelude::*};
-use crate::patch_class::PatchClass;
+use crate::AsChild;
 
 /// Displays a button.
 #[component]
@@ -242,48 +242,45 @@ pub fn Button(
 
     if as_child {
         Either::Right(view! {
-            {children()
-                .add_any_attr(
-                    leptos::tachys::html::class::class(
-                        PatchClass(
-                            Signal::derive(move || {
-                                format!(
-                                    "{} {} {}",
-                                    match variant.get().unwrap_or_default().as_str() {
-                                        "primary" => "singlestage-btn-primary",
-                                        "secondary" => "singlestage-btn-secondary",
-                                        "outline" => "singlestage-btn-outline",
-                                        "ghost" => "singlestage-btn-ghost",
-                                        "link" => "singlestage-btn-link",
-                                        "destructive" => "singlestage-btn-destructive",
-                                        _ => "singlestage-btn-primary",
-                                    },
-                                    match size.get().unwrap_or_default().as_str() {
-                                        "sm" => "singlestage-btn-sm",
-                                        "small" => "singlestage-btn-sm",
-                                        "lg" => "singlestage-btn-lg",
-                                        "large" => "singlestage-btn-lg",
-                                        "icon" => "singlestage-btn-icon",
-                                        "sm-icon" => "singlestage-btn-sm-icon",
-                                        "icon-sm" => "singlestage-btn-sm-icon",
-                                        "lg-icon" => "singlestage-btn-lg-icon",
-                                        "icon-lg" => "singlestage-btn-lg-icon",
-                                        _ => "",
-                                    },
-                                    class.get().unwrap_or_default(),
-                                )
-                            }),
-                        ),
-                    ),
-                )
-                .add_any_attr(
-                    leptos::tachys::html::property::prop("disabled", disabled.get_untracked()),
-                )
-                .attr("disabled", disabled.get_untracked())
-                .attr("type", button_type.get())
-                .add_any_attr(global_attrs_1)
-                .add_any_attr(global_attrs_2)
-                .add_any_attr(button_attrs)}
+            <AsChild
+                class=move || {
+                    format!(
+                        "{} {} {}",
+                        match variant.get().unwrap_or_default().as_str() {
+                            "primary" => "singlestage-btn-primary",
+                            "secondary" => "singlestage-btn-secondary",
+                            "outline" => "singlestage-btn-outline",
+                            "ghost" => "singlestage-btn-ghost",
+                            "link" => "singlestage-btn-link",
+                            "destructive" => "singlestage-btn-destructive",
+                            _ => "singlestage-btn-primary",
+                        },
+                        match size.get().unwrap_or_default().as_str() {
+                            "sm" => "singlestage-btn-sm",
+                            "small" => "singlestage-btn-sm",
+                            "lg" => "singlestage-btn-lg",
+                            "large" => "singlestage-btn-lg",
+                            "icon" => "singlestage-btn-icon",
+                            "sm-icon" => "singlestage-btn-sm-icon",
+                            "icon-sm" => "singlestage-btn-sm-icon",
+                            "lg-icon" => "singlestage-btn-lg-icon",
+                            "icon-lg" => "singlestage-btn-lg-icon",
+                            _ => "",
+                        },
+                        class.get().unwrap_or_default(),
+                    )
+                }
+                {..}
+                disabled=disabled.get_untracked()
+                prop:disabled=move || disabled.get()
+                type=button_type.get()
+
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </AsChild>
         })
     } else {
         Either::Left(view! {

--- a/singlestage/src/components/dropdown/trigger.rs
+++ b/singlestage/src/components/dropdown/trigger.rs
@@ -1,5 +1,5 @@
-use crate::DropdownMenuContext;
-use leptos::prelude::*;
+use crate::{AsChild, DropdownMenuContext};
+use leptos::{either::Either, prelude::*};
 
 /// The button that toggles the dropdown menu.
 #[component]
@@ -164,6 +164,9 @@ pub fn DropdownMenuTrigger(
     /// Variants: primary | secondary | outline | ghost | link | destructive
     #[prop(optional, into)]
     variant: MaybeProp<String>,
+
+    /// asChild
+    #[prop(optional)] as_child: bool,
 ) -> impl IntoView {
     let menu = expect_context::<DropdownMenuContext>();
 
@@ -221,44 +224,86 @@ pub fn DropdownMenuTrigger(
             value=move || value.get()
         />
     };
+    if as_child {
+        Either::Right(view! {
+            <AsChild
+                class=move || {
+                    format!(
+                        "{} {} {}",
+                        match variant.get().unwrap_or_default().as_str() {
+                            "primary" => "singlestage-btn-primary",
+                            "secondary" => "singlestage-btn-secondary",
+                            "outline" => "singlestage-btn-outline",
+                            "ghost" => "singlestage-btn-ghost",
+                            "link" => "singlestage-btn-link",
+                            "destructive" => "singlestage-btn-destructive",
+                            _ => "singlestage-btn-primary",
+                        },
+                        match size.get().unwrap_or_default().as_str() {
+                            "small" => "singlestage-btn-sm",
+                            "large" => "singlestage-btn-lg",
+                            "icon" => "singlestage-btn-icon",
+                            "sm-icon" => "singlestage-btn-sm-icon",
+                            "lg-icon" => "singlestage-btn-lg-icon",
+                            _ => "",
+                        },
+                        class.get().unwrap_or_default(),
+                    )
+                }
+                {..}
+                aria-controls=move || menu.menu_id.get()
+                aria-haspopup="menu"
+                popovertarget=move || menu.menu_id.get()
+                popovertargetaction="toggle"
+                id=uuid
+                type=button_type.get()
 
-    view! {
-        <button
-            aria-controls=move || menu.menu_id.get()
-            aria-haspopup="menu"
-            popovertarget=move || menu.menu_id.get()
-            popovertargetaction="toggle"
-            class=move || {
-                format!(
-                    "{} {} {}",
-                    match variant.get().unwrap_or_default().as_str() {
-                        "primary" => "singlestage-btn-primary",
-                        "secondary" => "singlestage-btn-secondary",
-                        "outline" => "singlestage-btn-outline",
-                        "ghost" => "singlestage-btn-ghost",
-                        "link" => "singlestage-btn-link",
-                        "destructive" => "singlestage-btn-destructive",
-                        _ => "singlestage-btn-primary",
-                    },
-                    match size.get().unwrap_or_default().as_str() {
-                        "small" => "singlestage-btn-sm",
-                        "large" => "singlestage-btn-lg",
-                        "icon" => "singlestage-btn-icon",
-                        "sm-icon" => "singlestage-btn-sm-icon",
-                        "lg-icon" => "singlestage-btn-lg-icon",
-                        _ => "",
-                    },
-                    class.get().unwrap_or_default(),
-                )
-            }
-            id=uuid
-            type=button_type.get()
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </AsChild>
+        })
+    } else {
+        Either::Left(view! {
+            <button
+                aria-controls=move || menu.menu_id.get()
+                aria-haspopup="menu"
+                popovertarget=move || menu.menu_id.get()
+                popovertargetaction="toggle"
+                class=move || {
+                    format!(
+                        "{} {} {}",
+                        match variant.get().unwrap_or_default().as_str() {
+                            "primary" => "singlestage-btn-primary",
+                            "secondary" => "singlestage-btn-secondary",
+                            "outline" => "singlestage-btn-outline",
+                            "ghost" => "singlestage-btn-ghost",
+                            "link" => "singlestage-btn-link",
+                            "destructive" => "singlestage-btn-destructive",
+                            _ => "singlestage-btn-primary",
+                        },
+                        match size.get().unwrap_or_default().as_str() {
+                            "small" => "singlestage-btn-sm",
+                            "large" => "singlestage-btn-lg",
+                            "icon" => "singlestage-btn-icon",
+                            "sm-icon" => "singlestage-btn-sm-icon",
+                            "lg-icon" => "singlestage-btn-lg-icon",
+                            _ => "",
+                        },
+                        class.get().unwrap_or_default(),
+                    )
+                }
+                id=uuid
+                type=button_type.get()
 
-            {..global_attrs_1}
-            {..global_attrs_2}
-            {..button_attrs}
-        >
-            {children()}
-        </button>
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </button>
+        })
     }
 }

--- a/singlestage/src/components/popover/trigger.rs
+++ b/singlestage/src/components/popover/trigger.rs
@@ -1,5 +1,6 @@
+use crate::AsChild;
 use super::PopoverContext;
-use leptos::prelude::*;
+use leptos::{either::Either, prelude::*};
 
 /// The button that toggles the popover.
 #[component]
@@ -164,6 +165,9 @@ pub fn PopoverTrigger(
     /// Variants: primary | secondary | outline | ghost | link | destructive
     #[prop(optional, into)]
     variant: MaybeProp<String>,
+    
+    /// asChild
+    #[prop(optional)] as_child: bool,
 ) -> impl IntoView {
     let menu = expect_context::<PopoverContext>();
 
@@ -222,43 +226,88 @@ pub fn PopoverTrigger(
         />
     };
 
-    view! {
-        <button
-            aria-controls=move || menu.menu_id.get()
-            aria-haspopup="menu"
-            popovertarget=move || menu.menu_id.get()
-            popovertargetaction="toggle"
-            class=move || {
-                format!(
-                    "{} {} {}",
-                    match variant.get().unwrap_or_default().as_str() {
-                        "primary" => "singlestage-btn-primary",
-                        "secondary" => "singlestage-btn-secondary",
-                        "outline" => "singlestage-btn-outline",
-                        "ghost" => "singlestage-btn-ghost",
-                        "link" => "singlestage-btn-link",
-                        "destructive" => "singlestage-btn-destructive",
-                        _ => "singlestage-btn-primary",
-                    },
-                    match size.get().unwrap_or_default().as_str() {
-                        "small" => "singlestage-btn-sm",
-                        "large" => "singlestage-btn-lg",
-                        "icon" => "singlestage-btn-icon",
-                        "sm-icon" => "singlestage-btn-sm-icon",
-                        "lg-icon" => "singlestage-btn-lg-icon",
-                        _ => "",
-                    },
-                    class.get().unwrap_or_default(),
-                )
-            }
-            id=uuid
-            type=button_type.get()
+        if as_child {
+        Either::Right(view! {
+            <AsChild
+                class=move || {
+                    format!(
+                        "{} {} {}",
+                        match variant.get().unwrap_or_default().as_str() {
+                            "primary" => "singlestage-btn-primary",
+                            "secondary" => "singlestage-btn-secondary",
+                            "outline" => "singlestage-btn-outline",
+                            "ghost" => "singlestage-btn-ghost",
+                            "link" => "singlestage-btn-link",
+                            "destructive" => "singlestage-btn-destructive",
+                            _ => "singlestage-btn-primary",
+                        },
+                        match size.get().unwrap_or_default().as_str() {
+                            "small" => "singlestage-btn-sm",
+                            "large" => "singlestage-btn-lg",
+                            "icon" => "singlestage-btn-icon",
+                            "sm-icon" => "singlestage-btn-sm-icon",
+                            "lg-icon" => "singlestage-btn-lg-icon",
+                            _ => "",
+                        },
+                        class.get().unwrap_or_default(),
+                    )
+                }
+                {..}
+                aria-controls=move || menu.menu_id.get()
+                aria-haspopup="menu"
+                popovertarget=move || menu.menu_id.get()
+                popovertargetaction="toggle"
 
-            {..global_attrs_1}
-            {..global_attrs_2}
-            {..button_attrs}
-        >
-            {children()}
-        </button>
+                id=uuid
+                type=button_type.get()
+
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </AsChild>
+        })
+    } else {
+        Either::Left(view! {
+            <button
+                aria-controls=move || menu.menu_id.get()
+                aria-haspopup="menu"
+                popovertarget=move || menu.menu_id.get()
+                popovertargetaction="toggle"
+                class=move || {
+                    format!(
+                        "{} {} {}",
+                        match variant.get().unwrap_or_default().as_str() {
+                            "primary" => "singlestage-btn-primary",
+                            "secondary" => "singlestage-btn-secondary",
+                            "outline" => "singlestage-btn-outline",
+                            "ghost" => "singlestage-btn-ghost",
+                            "link" => "singlestage-btn-link",
+                            "destructive" => "singlestage-btn-destructive",
+                            _ => "singlestage-btn-primary",
+                        },
+                        match size.get().unwrap_or_default().as_str() {
+                            "small" => "singlestage-btn-sm",
+                            "large" => "singlestage-btn-lg",
+                            "icon" => "singlestage-btn-icon",
+                            "sm-icon" => "singlestage-btn-sm-icon",
+                            "lg-icon" => "singlestage-btn-lg-icon",
+                            _ => "",
+                        },
+                        class.get().unwrap_or_default(),
+                    )
+                }
+                id=uuid
+                type=button_type.get()
+
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </button>
+        })
     }
-}
+
+ }

--- a/singlestage/src/components/tabs/trigger.rs
+++ b/singlestage/src/components/tabs/trigger.rs
@@ -1,5 +1,7 @@
+use crate::AsChild;
+
 use super::TabsContext;
-use leptos::prelude::*;
+use leptos::{either::Either, prelude::*};
 
 #[component]
 pub fn TabsTrigger(
@@ -159,6 +161,9 @@ pub fn TabsTrigger(
     /// The value of the tab that this button triggers.
     #[prop(optional, into)]
     value: MaybeProp<String>,
+
+    /// asChild
+    #[prop(optional)] as_child: bool,
 ) -> impl IntoView {
     let tabs = expect_context::<TabsContext>();
 
@@ -171,7 +176,6 @@ pub fn TabsTrigger(
             accesskey=move || accesskey.get()
             autocapitalize=move || autocapitalize.get()
             autofocus=move || autofocus.get()
-            class=move || class.get()
             contenteditable=move || contenteditable.get()
             dir=move || dir.get()
             draggable=move || draggable.get()
@@ -220,36 +224,65 @@ pub fn TabsTrigger(
             value=move || value.get()
         />
     };
-
-    view! {
-        <button
-            aria-controls=move || format!("{}-panel", value.get().unwrap_or_default())
-            aria-selected=move || {
-                if let Some(value) = value.get() {
-                    if value == tabs.value.get() {
-                        "true"
+    if as_child {
+        Either::Right(view! {
+            <AsChild
+                class={move || class.get().unwrap_or_default()}
+                {..}
+                aria-controls=move || format!("{}-panel", value.get().unwrap_or_default())
+                aria-selected=move || {
+                    if let Some(value) = value.get() {
+                        if value == tabs.value.get() { "true" } else { "false" }
                     } else {
                         "false"
                     }
-                } else {
-                    "false"
                 }
-            }
-            id=move || format!("{}-tab", value.get().unwrap_or_default())
-            on:click=move |_| {
-                if let Some(value) = value.get_untracked() {
-                    tabs.value.set(value)
+                id=move || format!("{}-tab", value.get().unwrap_or_default())
+                on:click=move |_| {
+                    if let Some(value) = value.get_untracked() {
+                        tabs.value.set(value)
+                    }
                 }
-            }
-            role="tab"
-            tabindex="0"
-            type="button"
+                role="tab"
+                tabindex="0"
+                type="button"
 
-            {..global_attrs_1}
-            {..global_attrs_2}
-            {..button_attrs}
-        >
-            {children()}
-        </button>
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </AsChild>
+        })
+    } else {
+        Either::Left(view! {
+            <button
+                class=move || class.get()
+                aria-controls=move || format!("{}-panel", value.get().unwrap_or_default())
+                aria-selected=move || {
+                    if let Some(value) = value.get() {
+                        if value == tabs.value.get() { "true" } else { "false" }
+                    } else {
+                        "false"
+                    }
+                }
+                id=move || format!("{}-tab", value.get().unwrap_or_default())
+                on:click=move |_| {
+                    if let Some(value) = value.get_untracked() {
+                        tabs.value.set(value)
+                    }
+                }
+                role="tab"
+                tabindex="0"
+                type="button"
+
+                {..global_attrs_1}
+                {..global_attrs_2}
+                {..button_attrs}
+            >
+                {children()}
+            </button>
+        })
     }
 }
+ 

--- a/singlestage/src/lib.rs
+++ b/singlestage/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::module_inception)]
 use std::include_str;
+mod patch_class;
 mod components;
 pub mod reactive;
 pub use components::*;

--- a/singlestage/src/lib.rs
+++ b/singlestage/src/lib.rs
@@ -1,6 +1,8 @@
 #![allow(clippy::module_inception)]
 use std::include_str;
 mod patch_class;
+mod as_child;
+pub use as_child::AsChild;
 mod components;
 pub mod reactive;
 pub use components::*;

--- a/singlestage/src/patch_class.rs
+++ b/singlestage/src/patch_class.rs
@@ -1,5 +1,5 @@
  use leptos::{
-    prelude::{Get, RenderEffect, Signal},
+    prelude::{Get, Oco, RenderEffect, Signal, TextProp},
     tachys::{
         html::class::IntoClass,
         renderer::{
@@ -10,24 +10,20 @@
 };
 
 /// A CSS class whose value lives in a **signal** that produces a `String`.
-#[derive(Debug)]
-pub struct PatchClass<S>(pub S);
+#[derive(Debug, Default, Clone)]
+pub struct PatchClass(pub TextProp);
 
-impl<S> Clone for PatchClass<S>
-where
-    S: Clone,
+impl<S> From<S> for PatchClass
+where S: Into<TextProp>
 {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
+    fn from(value: S) -> Self {
+        Self(value.into())
     }
 }
-
-impl<S> IntoClass for PatchClass<S>
-where
-    S: Into<Signal<String>> + Send + Clone + 'static,
-{
+impl IntoClass for PatchClass 
+ {
     type AsyncOutput = Self;
-    type State = RenderEffect<(Element, String)>;
+    type State = RenderEffect<(Element, Oco<'static, str>)>;
     type Cloneable = Self;
     type CloneableOwned = Self;
 
@@ -38,14 +34,14 @@ where
     }
 
     fn to_html(self, class: &mut String) {
-        class.push_str(&self.0.into().get());
+        class.push_str(&self.0.get());
     }
 
     fn hydrate<const FROM_SERVER: bool>(self, el: &Element) -> Self::State {
         let class_list = Rndr::class_list(el);
-        let signal = self.0.into();
+        let signal = self.0;
         let el = el.clone();
-        RenderEffect::new(move |prev: Option<(Element, String)>| {
+        RenderEffect::new(move |prev: Option<(Element, Oco<'static, str>)>| {
             let value = signal.get();
             let tokens = split_tokens(&value);
 
@@ -66,9 +62,9 @@ where
 
     fn build(self, el: &Element) -> Self::State {
         let class_list = Rndr::class_list(el);
-        let signal = self.0.into();
+        let signal = self.0;
         let el = el.clone();
-        RenderEffect::new(move |prev: Option<(Element, String)>| {
+        RenderEffect::new(move |prev: Option<(Element, Oco<'static, str>)>| {
             let value = signal.get();
             let tokens = split_tokens(&value);
 
@@ -87,9 +83,9 @@ where
 
     fn rebuild(self, state: &mut Self::State) {
         let prev = state.take_value();
-        let signal = self.0.into();
+        let signal = self.0;
         *state = RenderEffect::new_with_value(
-            move |prev: Option<(Element, String)>| {
+            move |prev: Option<(Element, Oco<'static, str>)>| {
                 let value = signal.get();
                 let tokens = split_tokens(&value);
 

--- a/singlestage/src/patch_class.rs
+++ b/singlestage/src/patch_class.rs
@@ -1,0 +1,151 @@
+ use leptos::{
+    prelude::{Get, RenderEffect, Signal},
+    tachys::{
+        html::class::IntoClass,
+        renderer::{
+            Rndr,
+            dom::{ClassList, Element},
+        },
+    },
+};
+
+/// A CSS class whose value lives in a **signal** that produces a `String`.
+#[derive(Debug)]
+pub struct PatchClass<S>(pub S);
+
+impl<S> Clone for PatchClass<S>
+where
+    S: Clone,
+{
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<S> IntoClass for PatchClass<S>
+where
+    S: Into<Signal<String>> + Send + Clone + 'static,
+{
+    type AsyncOutput = Self;
+    type State = RenderEffect<(Element, String)>;
+    type Cloneable = Self;
+    type CloneableOwned = Self;
+
+    const MIN_LENGTH: usize = 0;
+
+    fn html_len(&self) -> usize {
+        0
+    }
+
+    fn to_html(self, class: &mut String) {
+        class.push_str(&self.0.into().get());
+    }
+
+    fn hydrate<const FROM_SERVER: bool>(self, el: &Element) -> Self::State {
+        let class_list = Rndr::class_list(el);
+        let signal = self.0.into();
+        let el = el.clone();
+        RenderEffect::new(move |prev: Option<(Element, String)>| {
+            let value = signal.get();
+            let tokens = split_tokens(&value);
+
+            if let Some((element, old_value)) = prev {
+                let old_tokens = split_tokens(&old_value);
+                diff_and_apply(&class_list, &old_tokens, &tokens);
+                (element, value)
+            } else {
+                if !FROM_SERVER {
+                    for token in &tokens {
+                        Rndr::add_class(&class_list, token);
+                    }
+                }
+                (el.clone(), value)
+            }
+        })
+    }
+
+    fn build(self, el: &Element) -> Self::State {
+        let class_list = Rndr::class_list(el);
+        let signal = self.0.into();
+        let el = el.clone();
+        RenderEffect::new(move |prev: Option<(Element, String)>| {
+            let value = signal.get();
+            let tokens = split_tokens(&value);
+
+            if let Some((element, old_value)) = prev {
+                let old_tokens = split_tokens(&old_value);
+                diff_and_apply(&class_list, &old_tokens, &tokens);
+                (element, value)
+            } else {
+                for token in &tokens {
+                    Rndr::add_class(&class_list, token);
+                }
+                (el.clone(), value)
+            }
+        })
+    }
+
+    fn rebuild(self, state: &mut Self::State) {
+        let prev = state.take_value();
+        let signal = self.0.into();
+        *state = RenderEffect::new_with_value(
+            move |prev: Option<(Element, String)>| {
+                let value = signal.get();
+                let tokens = split_tokens(&value);
+
+                let (element, old_value) = prev.unwrap();
+                let old_tokens = split_tokens(&old_value);
+                let class_list = Rndr::class_list(&element);
+                diff_and_apply(&class_list, &old_tokens, &tokens);
+                (element, value)
+            },
+            prev,
+        );
+    }
+
+    fn into_cloneable(self) -> Self::Cloneable {
+        self
+    }
+
+    fn into_cloneable_owned(self) -> Self::CloneableOwned {
+        self
+    }
+
+    fn dry_resolve(&mut self) {}
+
+    async fn resolve(self) -> Self::AsyncOutput {
+        self
+    }
+
+    fn reset(state: &mut Self::State) {
+        *state = RenderEffect::new_with_value(
+            move |prev| {
+                if let Some((element, value)) = prev {
+                    Rndr::remove_attribute(&element, "class");
+                    (element, value)
+                } else {
+                    unreachable!("reset called without state")
+                }
+            },
+            state.take_value(),
+        );
+    }
+}
+
+#[inline]
+fn diff_and_apply(class_list: &ClassList, old_tokens: &[&str], new_tokens: &[&str]) {
+    for token in old_tokens.iter() {
+        if !new_tokens.contains(token) {
+            Rndr::remove_class(class_list, token);
+        }
+    }
+
+    for token in new_tokens.iter() {
+        Rndr::add_class(class_list, token);
+    }
+}
+
+#[inline]
+fn split_tokens(s: &str) -> Vec<&str> {
+    s.split_whitespace().collect()
+}


### PR DESCRIPTION
This is not a ready-to-merge PR. I just had an idea and wanted to share it.

I implemented a very naive `as_child` mechanism in the Button component, which passes the children directly without the button element.

This probably comes with a lot of edge cases that I haven't tested.

In comparison to Radix UI, in all conflicts, the parent wins, except for classes, which will merge because of the new `PatchClass` type I declared (it probably has room for further optimization and improvement).
