### PR TITLE
feat: add nonce support to the theme style element

### DIFF
--- a/singlestage/Cargo.toml
+++ b/singlestage/Cargo.toml
@@ -31,6 +31,7 @@ ssr = ["leptos/ssr"]
 hydrate = ["leptos/hydrate"]
 islands = ["serde/derive", "leptos/islands"]
 nightly = ["leptos/nightly"]
+nonce = ["leptos/nonce", "leptos_meta/nonce"]
 stores = ["dep:reactive_stores"]
 default = [
   "accordion",

--- a/singlestage/src/components/theme_provider/mod.rs
+++ b/singlestage/src/components/theme_provider/mod.rs
@@ -506,6 +506,19 @@ static DARK_OVERRIDES: &str = r#"@layer components {
   }
 }"#;
 
+/// Provides nonce support for inline styles. Returns `None` if the `nonce`
+/// feature is not enabled or no nonce is in context.
+fn request_nonce() -> Option<String> {
+    #[cfg(feature = "nonce")]
+    {
+        leptos::nonce::use_nonce().map(|n| n.to_string())
+    }
+    #[cfg(not(feature = "nonce"))]
+    {
+        None
+    }
+}
+
 /// Provides theme support to children. Note: Setting `mode` and `theme` here are only used for
 /// initial values. Updates should be done via `ThemeProviderContext`.
 #[component]
@@ -530,6 +543,7 @@ pub fn ThemeProviderInner(
         <Style id="singlestage">{CSS}</Style>
         <style
             id="theme"
+            nonce=request_nonce()
             inner_html=move || {
                 let theme = theme.get();
                 match mode.get() {


### PR DESCRIPTION
Enables strict ``style-src`` CSP when using ``ThemeProvider``.

Problem: If someone adds a nonce in the header, then the browser is going to block the relevant elements that dont match said nonce, and 'unsafe-inline' is ignored if a nonce is present.

Cause: ``ThemeProviderInner`` has two inline styles. The ``<Style id="singlestage">`` uses ``leptos_meta``, which auto-attaches a nonce when the ``leptos_meta`` nonce feature is enabled and a nonce is in the context, and the ``<style id="theme"...>`` is a pure html element which has no logic for attaching a nonce regardless of enabled features or whether a nonce is available. I initially became aware of the problem as I had a nonce due to ``leptos_axum`` but ZAP, aka Zed Attack Proxy, flagged my app with the finding "CSP: style-src unsafe-inline" and from there I narrowed it down to the theme style element.

Change: an opt-in nonce feature for ``singlestage-ui``. This ensures users of the library can have a strict CSP policy for style elements. This should be optional as not everyone needs a nonce all the time, and when going through the leptos code they use an optional, feature based system to determine whether to add a nonce.

Tested: I am making a portfolio ``leptos_axum`` app with SSR and ran ZAP against it after making the above changes. I also added a temp button for dark/light mode toggling to ensure that switching between the two modes did not have an adverse effect due to the nonce.