### PR TITLE
fix: tooltip layout shift on click

### DIFF
--- a/singlestage/src/components/tooltip/content.rs
+++ b/singlestage/src/components/tooltip/content.rs
@@ -187,11 +187,9 @@ pub fn TooltipContent(
             node_ref=content_ref
             popover="hint"
             style:position-anchor=move || format!("--{}", tooltip.trigger_id.get())
-            // TODO: This should probably be done with css
-            style:display=move || {
-                match tooltip.open.get() {
-                    true => "contents",
-                    false => "none"
+            on:toggle=move |_| {
+                if let Some(content) = content_ref.get_untracked() {
+                    tooltip.open.set(content.matches(":popover-open").unwrap_or(false));
                 }
             }
 


### PR DESCRIPTION
Hello, this small bug annoyed me enough that I ended up fixing it while on holiday from work

Not sure it's the right fix though. That inline `display` may have been a fallback for browsers without popover support, and I only tested Firefox and Brave.